### PR TITLE
Fix building from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@
 docs/
 lib/
 script/
-src/
 test/
 .gitattributes
 .gitignore
@@ -18,4 +17,4 @@ jest.json
 .node-version
 .github
 dist/test
-binding.gyp
+jest.config.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "win32-user-locale",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A thin wrapper on top of GetLocaleInfoEx",
   "main": "dist/lib/index.js",
   "typings": "dist/lib/index.d.ts",


### PR DESCRIPTION
Seems I got a little carried away writing the npmignore and ignored the files needed to build the native module.